### PR TITLE
Create a wrapper element

### DIFF
--- a/index.css
+++ b/index.css
@@ -12,7 +12,7 @@
 }
 
 .header__wrapper {
-  max-width: var(--site-max-width, 1000px);
+  max-width: var(--site-max-width, 1190px);
   margin: 0 auto;
 }
 

--- a/index.css
+++ b/index.css
@@ -11,6 +11,11 @@
   background-repeat: no-repeat;
 }
 
+.header__wrapper {
+  max-width: var(--site-max-width, 1000px);
+  margin: 0 auto;
+}
+
 .header__group-text {
   display: flex;
   flex-direction: column;
@@ -64,7 +69,7 @@
 }
 
 @media (--viewport-small) {
-  .header {
+  .header__wrapper {
     padding:  var(--header-padding-top, 150px) var(--grid-gutter-m) var(--header-padding-bottom, var(--grid-spacing-hedgehog));
     height: var(--header-height, 430px);
     flex: 1;
@@ -88,11 +93,13 @@
 /* Desktop version */
 @media (--viewport-big) {
   .header {
+    background-image: none !important;
+    padding:  var(--header-padding-top, var(--grid-spacing-hedgehog)) var(--grid-gutter-m) var(--header-padding-bottom, var(--grid-spacing-hedgehog));
+  }
+  .header__wrapper {
     flex-direction: row-reverse;
     display: flex;
-    background-image: none !important;
     height: var(--header-viewport-big-height, 300px);
-    padding:  var(--header-padding-top, var(--grid-spacing-hedgehog)) var(--grid-gutter-m) var(--header-padding-bottom, var(--grid-spacing-hedgehog));
   }
 
   .header__group-text {

--- a/index.es6
+++ b/index.es6
@@ -100,7 +100,11 @@ export default class Header extends React.Component {
         itemScope itemType={this.props.itemType} itemProp={this.props.itemProp}
         role="header"
         style={inlineStyle}
-      >{groups}</header>
+      >
+        <div className="header__wrapper">
+          {groups}
+        </div>
+      </header>
     );
   }
 }


### PR DESCRIPTION
Currently the width of this component is unbounded. That is, it can be as large as the user's monitor.

To control this width, we have to add a max-width to the component. But not in a way that removes the blue background, which should grow unbounded.

Thus, I've added a simple wrapper, whose purpose is to have a max-width and be centered.

If you're wondering where `--site-max-width` came from, it's what we're using in the footer as well.