### PR TITLE
fix: Remove reference to unknown font

### DIFF
--- a/blogCustomisation.css
+++ b/blogCustomisation.css
@@ -3,7 +3,6 @@
 .header__additional-element {
   color: var(--header__additional-element-color, var(--color-thimphu));
   margin: var(--grid-spacing-sheep) 0;
-  font-family: 'Halifax Regular';
 }
 
 .header__follow-us-title {


### PR DESCRIPTION
It's okay to remove it without a replacement, since it will inherit from `.header`'s font-family.